### PR TITLE
fix: 分钟线增量 code 格式不匹配

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -40,9 +40,12 @@ def sync_single_stock_min_data(
         start_date: 开始日期
         incremental: 是否启用精确增量
     """
+    # DB 中 code 为纯 6 位数字（reader 写入时会截取），查询时需匹配
+    db_code = code[-6:] if len(code) > 6 else code
+
     # 精确增量：查询该股票的最新日期
     if incremental and not start_date:
-        latest = storage.get_latest_datetime_by_code('minute5_data', code)
+        latest = storage.get_latest_datetime_by_code('minute5_data', db_code)
         if latest:
             start_date = (latest + timedelta(days=1)).strftime('%Y-%m-%d')
             logger.debug(f"{code} 增量起始日期: {start_date}")


### PR DESCRIPTION
## Summary
- `get_latest_datetime_by_code` 用带市场前缀的 code（如 `sz000001`）查询，但 DB 中存储的是纯 6 位数字（`000001`）
- 导致查询永远返回 None → 每次 sync 都全量处理所有分钟数据
- 修复：查询前截取 `code[-6:]` 匹配 DB 格式

## Test plan
- [x] 验证 `sz000001` 查询返回 None，`000001` 查询返回正确日期
- [ ] 运行 `python main.py sync`，确认分钟线增量跳过已有数据

🤖 Generated with [Claude Code](https://claude.com/claude-code)