### PR TITLE
fix: 分钟线增量改回溯窗口，修复历史空洞被永久跳过 (#7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ CLI (cli.py)  → Reader (reader.py) → Processor (processor.py) → Storage (s
 1. **日线**: 逐股票读取 `vipdoc/{sz,sh}/lday/*.day` → `process_daily_data()` 校验 OHLCV + 计算均线 → 增量写入 `daily_data` 表
 2. **分钟线**: 逐股票读取 `.lc5`（5 分钟）→ `resample_ohlcv()` 重采样为 15/30/60 分钟 → `process_min_data()` 校验 + 均线 → 分别写入 `minute{5,15,30,60}_data` 表
 3. **增量同步**: `save_incremental()` 使用批量 executemany + `ON CONFLICT DO NOTHING`（PostgreSQL）/ `INSERT IGNORE`（MySQL）跳过重复。分钟线按股票精确查询最新日期（`get_latest_datetime_by_code`），日线逐股票增量。
+4. **回溯窗口**: 分钟线增量起点 = `latest - LOOKBACK_DAYS`（默认 30 天，cli.py 顶部常量），不是 `latest + 1`。原因：TDX `.lc5` 拉取存在滞后，「latest+1」会把后置日期入库后导致前置空洞被永久跳过；ON CONFLICT 保证重复插入零副作用。修复旧数据用 `scripts/backfill_minute_gaps.py` 全量重读。
 
 ### 数据库表
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,21 @@ python main.py minutes --csv-only
 ```
 </details>
 
+<details>
+<summary>修复历史空洞（minute 数据）</summary>
+
+如果发现 minute5/15/30/60 表存在历史日期空洞（例如某些股票在某天缺数据），
+可运行一次性回填脚本，从 TDX `.lc5` 全量重读 + ON CONFLICT 自动只补缺失：
+
+```bash
+python scripts/backfill_minute_gaps.py            # 全市场（约 1-2 小时）
+python scripts/backfill_minute_gaps.py --code sz000001
+python scripts/backfill_minute_gaps.py --dry-run  # 看流程不写库
+```
+
+> 自 2026-05 起，`sync` 默认回溯 30 天写入，新空洞不会再形成；本脚本仅用于修旧数据。
+</details>
+
 ## 数据库支持
 
 - PostgreSQL（推荐）

--- a/scripts/backfill_minute_gaps.py
+++ b/scripts/backfill_minute_gaps.py
@@ -1,0 +1,118 @@
+"""一次性回填脚本：补齐 minute5/15/30/60 数据的历史空洞
+
+背景：在引入回溯窗口（cli.py LOOKBACK_DAYS）之前，旧的「latest+1」增量逻辑
+会把 TDX .lc5 滞后导致的空洞永久跳过。本脚本对每只股票从 .lc5 全量重读，
+依靠数据库 (code, datetime) 唯一约束 + ON CONFLICT DO NOTHING 自动只补缺失。
+
+用法：
+    # 全市场回填（默认）
+    python scripts/backfill_minute_gaps.py
+
+    # 单只股票
+    python scripts/backfill_minute_gaps.py --code sz000001
+
+    # dry-run（只跑流程不写库）
+    python scripts/backfill_minute_gaps.py --dry-run --code sz000001
+
+注意：回填走完整 .lc5，单只股票约 1-3 秒，全市场约 1-2 小时。可中断重跑。
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+# 允许 `python scripts/backfill_minute_gaps.py` 直接跑
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tqdm import tqdm
+
+from src.cli import sync_single_stock_min_data
+from src.config import config
+from src.logger import logger
+from src.processor import DataProcessor
+from src.reader import TdxDataReader
+from src.storage import DataStorage
+
+# 远早于任何 A 股数据的日期，传入后等价于不过滤
+EARLIEST_DATE = '1990-01-01'
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='回填 minute5/15/30/60 数据空洞')
+    parser.add_argument('--code', help='仅处理指定股票，例如 sz000001 / sh600000；不指定则全市场')
+    parser.add_argument('--dry-run', action='store_true', help='不实际写库，只打印流程')
+    parser.add_argument('--no-tqdm', action='store_true', help='禁用进度条')
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.no_tqdm:
+        config.use_tqdm = False
+
+    try:
+        reader = TdxDataReader()
+    except (ValueError, FileNotFoundError) as e:
+        logger.error(f"初始化 reader 失败: {e}")
+        return 1
+
+    storage = DataStorage()
+    processor = DataProcessor()
+
+    # 收集要处理的股票
+    if args.code:
+        code = args.code
+        market = 1 if code.startswith('sh') else 0
+        stocks = [(market, code)]
+    else:
+        try:
+            df = reader.get_stock_list()
+        except FileNotFoundError as e:
+            logger.error(f"获取股票列表失败: {e}")
+            return 1
+        stocks = [
+            (1 if row['code'].startswith('sh') else 0, row['code'])
+            for _, row in df.iterrows()
+        ]
+
+    logger.info(f"准备回填 {len(stocks)} 只股票（dry_run={args.dry_run}）")
+
+    if args.dry_run:
+        for market, code in stocks[:5]:
+            logger.info(f"[dry-run] 将回填 market={market} code={code} from {EARLIEST_DATE}")
+        if len(stocks) > 5:
+            logger.info(f"[dry-run] ...（省略 {len(stocks) - 5} 只）")
+        logger.info("[dry-run] 未实际写库")
+        return 0
+
+    iterator = tqdm(stocks) if config.use_tqdm else stocks
+    success_cnt = 0
+    skip_cnt = 0
+    err_cnt = 0
+
+    for market, code in iterator:
+        try:
+            ok = sync_single_stock_min_data(
+                reader, processor, storage,
+                market, code,
+                start_date=EARLIEST_DATE,  # 跳过 cli.py 的 lookback 分支，过滤等价于全量
+                incremental=True,           # 走 save_incremental → ON CONFLICT DO NOTHING
+            )
+            if ok:
+                success_cnt += 1
+            else:
+                skip_cnt += 1
+        except FileNotFoundError:
+            skip_cnt += 1
+        except Exception as e:
+            logger.error(f"回填 {code} 失败: {e}")
+            err_cnt += 1
+
+    logger.info(
+        f"回填完成: success={success_cnt} skip={skip_cnt} error={err_cnt}"
+    )
+    return 0 if err_cnt == 0 else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/cli.py
+++ b/src/cli.py
@@ -19,6 +19,13 @@ from .storage import DataStorage
 from .config import config
 from .logger import logger
 
+# 增量同步回溯窗口（天数）
+# 不用 latest+1 作为起点，而是 latest-N。理由：
+# 1. TDX .lc5 拉取存在滞后（部分股票当日不一定及时更新），后续补上后旧空洞会被永久跳过
+# 2. 数据库 (code, datetime) 唯一约束 + ON CONFLICT DO NOTHING 保证重复插入零副作用
+# 3. .lc5 文件无论如何都会被全文件读取，回溯只多过滤几天数据，IO 不增加
+LOOKBACK_DAYS = 30
+
 
 def sync_single_stock_min_data(
     reader: TdxDataReader,
@@ -43,12 +50,12 @@ def sync_single_stock_min_data(
     # DB 中 code 为纯 6 位数字（reader 写入时会截取），查询时需匹配
     db_code = code[-6:] if len(code) > 6 else code
 
-    # 精确增量：查询该股票的最新日期
+    # 精确增量：查询该股票的最新日期，回溯 LOOKBACK_DAYS 天作为起点
     if incremental and not start_date:
         latest = storage.get_latest_datetime_by_code('minute5_data', db_code)
         if latest:
-            start_date = (latest + timedelta(days=1)).strftime('%Y-%m-%d')
-            logger.debug(f"{code} 增量起始日期: {start_date}")
+            start_date = (latest - timedelta(days=LOOKBACK_DAYS)).strftime('%Y-%m-%d')
+            logger.debug(f"{code} 增量起始日期: {start_date} (latest={latest.date()}, lookback={LOOKBACK_DAYS}d)")
 
     # 读取5分钟数据
     df_5min = reader.read_5min_data(market, code)


### PR DESCRIPTION
## Summary

修复 #7。

- **cli.py**: 分钟线增量起点 `latest + 1` → `latest - 30`（`LOOKBACK_DAYS=30`）。配合 ON CONFLICT DO NOTHING 自动补 TDX `.lc5` 拉取滞后造成的空洞。
- **scripts/backfill_minute_gaps.py**: 一次性脚本，全量重读 `.lc5` 修旧空洞。
- README / CLAUDE.md 同步说明。

不在本 PR 范围（独立 follow-up）：
- `sync_all_daily_data` 用全局 max 而非 per-stock，类似但不同的隐患
- `get_latest_datetime_by_code` 只查 minute5 表导致的多表 cursor 不一致 — 当前 PR 通过回溯窗口已自然缓解

## Test plan

- [ ] 用 issue 复现 SQL 看当前空洞分布：
      `SELECT DATE(date), COUNT(DISTINCT code) FROM minute60_data WHERE date >= '2026-04-25' GROUP BY DATE(date) ORDER BY DATE(date);`
- [ ] 跑 `python scripts/backfill_minute_gaps.py --dry-run --code sz000001` 确认流程
- [ ] 跑 `python scripts/backfill_minute_gaps.py --code sz000001` 单只回填，对比该股票 04-28/29 数据是否补上
- [ ] 跑全量 `python scripts/backfill_minute_gaps.py`，重新跑复现 SQL 确认空洞消失
- [ ] 跑 `python main.py sync` 看耗时增加是否可接受（预期 +30-60s）

🤖 Generated with [Claude Code](https://claude.com/claude-code)