### PR TITLE
fix: 日线同步改为逐股票精确增量

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -103,7 +103,11 @@ def sync_all_daily_data(
     storage: DataStorage,
     start_date: Optional[str] = None,
 ) -> bool:
-    """逐股票流式同步日线数据，避免全量加载到内存"""
+    """逐股票流式同步日线数据，避免全量加载到内存
+
+    start_date=None 时按股票精确增量（查各自的 MAX(date)）。
+    全表 MAX(date) 做起点会把库里没有的新股全历史过滤掉（2026-06-12 科创/301 首次同步踩坑）。
+    """
     try:
         stocks = reader.get_stock_list()
         logger.info(f"同步日线数据，共 {len(stocks)} 只股票")
@@ -115,6 +119,15 @@ def sync_all_daily_data(
             code = stock['code']
             market = 1 if code.startswith('sh') else 0
             try:
+                # 精确增量：该股票自己的最新日期；新股 latest=None → 全历史
+                stock_start = start_date
+                if stock_start is None:
+                    db_code = code[-6:] if len(code) > 6 else code
+                    latest = storage.get_latest_datetime_by_code(
+                        'daily_data', db_code, date_column='date')
+                    if latest:
+                        stock_start = (latest + timedelta(days=1)).strftime('%Y-%m-%d')
+
                 data = reader.read_daily_data(market, code)
                 if isinstance(data.index, pd.DatetimeIndex) or data.index.name == 'datetime':
                     data = data.reset_index()
@@ -122,7 +135,7 @@ def sync_all_daily_data(
                     continue
 
                 processed = processor.process_daily_data(data)
-                filtered = processor.filter_data(processed, start_date=start_date)
+                filtered = processor.filter_data(processed, start_date=stock_start)
                 if filtered.empty:
                     continue
 
@@ -439,16 +452,11 @@ def main() -> int:
         processor = DataProcessor()
         has_error = False
 
-        # 1. 同步日线数据
+        # 1. 同步日线数据（逐股票精确增量，不传全局 start_date——
+        #    全表 MAX(date) 会把新上市/新纳入股票的全历史过滤掉）
         try:
             logger.info("=== 同步日线数据 ===")
-            latest = storage.get_latest_datetime('daily_data', date_column='date')
-            start_date = None
-            if latest:
-                start_date = (latest + timedelta(days=1)).strftime('%Y-%m-%d')
-                logger.info(f"日线起始日期: {start_date}")
-
-            success = sync_all_daily_data(reader, processor, storage, start_date)
+            success = sync_all_daily_data(reader, processor, storage)
             if not success:
                 logger.error("同步日线数据时出错")
                 has_error = True

--- a/src/storage.py
+++ b/src/storage.py
@@ -260,21 +260,25 @@ class DataStorage:
     def get_latest_datetime_by_code(
         self,
         table_name: str,
-        code: str
+        code: str,
+        date_column: str = 'datetime'
     ) -> Optional[dt]:
         """获取指定股票的最新 datetime
 
         Args:
             table_name: 表名
             code: 股票代码
+            date_column: 日期列名（分钟表 datetime，日线表 date）
 
         Returns:
             Optional[datetime]: 最新的 datetime，如果没有数据则返回 None
         """
+        if date_column not in ('datetime', 'date'):
+            raise ValueError(f"非法日期列名: {date_column}")
         try:
             with self.engine.connect() as conn:
                 result = conn.execute(
-                    text(f"SELECT MAX(datetime) FROM {table_name} WHERE code = :code"),
+                    text(f"SELECT MAX({date_column}) FROM {table_name} WHERE code = :code"),
                     {"code": code}
                 )
                 row = result.fetchone()


### PR DESCRIPTION
## Summary
- `sync` 日线用全表 MAX(date) 做统一增量起点，库里没有的新股票全历史被 filter 过滤为空，**静默 0 行入库**。本次 #9 合入后首次同步科创/301 时暴露：分钟线（已是逐股票精确增量）54 只入库，日线 0 行
- `get_latest_datetime_by_code` 增加 `date_column` 参数（'datetime'/'date' 白名单），日线复用该方法逐股票查增量起点
- 新股 latest=None → 全历史；老股从自己最新日期+1 起

## Test plan
- [x] Dry-run 三路径：sh688981（新股，None → 1426 行全历史）/ sh600519（老股，2026-06-13 → 0 行）/ sz301236（新股，None → 1029 行）
- [ ] 全量 sync 后验证 daily_data 中 688=609 只 / 301=461 只
- [ ] 老股票行数不变（无重复插入，ON CONFLICT 兜底）

🤖 Generated with [Claude Code](https://claude.com/claude-code)