### PR TITLE
fix: daily --auto-start 改为逐股票精确增量

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -226,7 +226,7 @@ def parse_args() -> Namespace:
     daily_parser.add_argument('--end_date', help='结束日期，格式为YYYY-MM-DD')
     daily_parser.add_argument('--csv-only', action='store_true', help='仅保存到CSV')
     daily_parser.add_argument('--db-only', action='store_true', help='仅保存到数据库')
-    daily_parser.add_argument('--auto-start', action='store_true', help='自动检测起始日期（从数据库最新日期+1天开始）')
+    daily_parser.add_argument('--auto-start', action='store_true', help='自动检测起始日期（逐股票精确增量，各股票从自己的最新日期+1天开始）')
     daily_parser.add_argument('--incremental', action='store_true', help='增量同步模式，跳过重复数据')
 
     # 获取并计算分钟线数据
@@ -323,15 +323,28 @@ def main() -> int:
 
     elif args.command == 'daily':
         try:
-            # 处理 --auto-start 参数
             start_date = args.start_date
-            if hasattr(args, 'auto_start') and args.auto_start and not start_date:
-                latest = storage.get_latest_datetime('daily_data', date_column='date')
+
+            # --auto-start 全股票模式：逐股票精确增量（与 sync 命令同路径）。
+            # 全表 MAX(date)+1 做起点会在同步中断后把未完成股票的数据静默过滤掉（issue #12）
+            if hasattr(args, 'auto_start') and args.auto_start and not start_date and not args.code:
+                if not args.db_only:
+                    logger.warning("--auto-start 逐股票增量模式仅写入数据库，跳过 CSV 输出；如需 CSV 请显式指定 --start_date")
+                if args.end_date:
+                    logger.warning(f"--auto-start 逐股票增量模式忽略 --end_date {args.end_date}")
+                processor = DataProcessor()
+                success = sync_all_daily_data(reader, processor, storage)
+                return 0 if success else 1
+
+            # --auto-start 单股票模式：查该股票自己的最新日期，而非全表 MAX
+            if hasattr(args, 'auto_start') and args.auto_start and not start_date and args.code:
+                db_code = args.code[-6:] if len(args.code) > 6 else args.code
+                latest = storage.get_latest_datetime_by_code('daily_data', db_code, date_column='date')
                 if latest:
                     start_date = (latest + timedelta(days=1)).strftime('%Y-%m-%d')
-                    logger.info(f"自动检测起始日期: {start_date}")
+                    logger.info(f"自动检测 {args.code} 起始日期: {start_date}")
                 else:
-                    logger.info("数据库中没有数据，将获取所有数据")
+                    logger.info(f"数据库中没有 {args.code} 的数据，将获取全部历史")
 
             # 获取日线数据
             if args.code and args.market is not None:

--- a/src/cli.py
+++ b/src/cli.py
@@ -328,6 +328,9 @@ def main() -> int:
             # --auto-start 全股票模式：逐股票精确增量（与 sync 命令同路径）。
             # 全表 MAX(date)+1 做起点会在同步中断后把未完成股票的数据静默过滤掉（issue #12）
             if hasattr(args, 'auto_start') and args.auto_start and not start_date and not args.code:
+                if args.csv_only:
+                    logger.error("--auto-start 逐股票增量模式仅写入数据库，与 --csv-only 冲突；如需 CSV 请显式指定 --start_date")
+                    return 1
                 if not args.db_only:
                     logger.warning("--auto-start 逐股票增量模式仅写入数据库，跳过 CSV 输出；如需 CSV 请显式指定 --start_date")
                 if args.end_date:


### PR DESCRIPTION
Closes #12

## Summary

`daily --auto-start` 原用全表 `MAX(date)+1` 检测起始日期，任何一次同步中断后，已写入部分股票的最新日期会把其余股票的同批数据在过滤阶段静默丢弃（exit 0、无告警）。#10 已将 `sync` 命令改为逐股票精确增量，但 `daily` 命令路径是残留入口。

改动（仅 `src/cli.py`，+19/-6）：

- **全股票模式**（`--auto-start` 无 `--code`）：委托给 `sync_all_daily_data` 的逐股票精确增量，与 `sync` 命令同路径。该模式仅写 DB，若未指定 `--db-only` 或带 `--end_date` 会打 warning 说明
- **单股票模式**（`--auto-start` + `--code`）：改查该股票自己的最新日期（`get_latest_datetime_by_code`），个股落后于全表 MAX 时不再被跳过
- argparse help 文案同步更新

`minutes --auto-start` 存在同类模式，不在本 PR 范围（见 #11 / #12 说明）。

## Test plan

- [x] `py_compile` 通过
- [x] 单股票路径：`daily --code sz000001 --market 0 --db-only --auto-start --incremental` → 日志「自动检测 sz000001 起始日期: 2026-07-04」，无数据可插，exit 0
- [x] 全股票路径：`daily --db-only --auto-start --incremental`（即当日踩坑的原命令）→ 日志首行「同步日线数据，共 5198 只股票」（确认走新路径），结束「日线数据已是最新」，exit 0
- [x] 验证运行前后 `daily_data` 2026-07-03 行数不变（5149），无意外写入
- [ ] 中断恢复场景（bug 的原始触发条件）：本周已用显式 `--start_date` 补齐数据，无法非破坏性复现；逻辑与 `sync` 命令共用 `sync_all_daily_data`，该路径自 #10 起每周生产验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJPL3yLZNViUNDnPNzVDsD