### PR TITLE
fix: CI 全矩阵失败——reader.py F821 + 补最小测试套件

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ name = "aliyun"
 url = "https://mirrors.aliyun.com/pypi/simple/"
 priority = "primary"
 
+[tool.pytest.ini_options]
+pythonpath = ["."]
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/src/reader.py
+++ b/src/reader.py
@@ -432,4 +432,4 @@ class TdxDataReader:
         # except Exception as e:
         #     print(f"补充股票名称时出错: {e}")
 
-        return df
+        return blocks

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,0 +1,69 @@
+"""processor 纯函数单元测试（CI pytest 步骤的最小真实测试套件，issue #14）"""
+
+import pandas as pd
+import pytest
+
+from src.processor import DataProcessor, MA_WINDOWS
+
+
+@pytest.fixture
+def daily_df():
+    """两只股票各 6 天的最小日线数据"""
+    rows = []
+    for code in ['000001', '600000']:
+        for i, day in enumerate(pd.date_range('2026-01-05', periods=6)):
+            price = 10.0 + i if code == '000001' else 20.0 + i
+            rows.append({
+                'code': code, 'date': day,
+                'open': price, 'high': price + 0.5, 'low': price - 0.5,
+                'close': price, 'volume': 1000 + i, 'amount': price * (1000 + i),
+            })
+    return pd.DataFrame(rows)
+
+
+class TestFilterData:
+    def test_start_date_inclusive(self, daily_df):
+        out = DataProcessor.filter_data(daily_df, start_date='2026-01-08')
+        assert out['date'].min() == pd.Timestamp('2026-01-08')
+        assert len(out) == 6  # 每只股票剩 3 天
+
+    def test_end_date_inclusive(self, daily_df):
+        out = DataProcessor.filter_data(daily_df, end_date='2026-01-06')
+        assert out['date'].max() == pd.Timestamp('2026-01-06')
+        assert len(out) == 4
+
+    def test_codes_filter(self, daily_df):
+        out = DataProcessor.filter_data(daily_df, codes=['600000'])
+        assert set(out['code']) == {'600000'}
+
+    def test_no_filter_returns_all(self, daily_df):
+        assert len(DataProcessor.filter_data(daily_df)) == len(daily_df)
+
+    def test_empty_df_passthrough(self):
+        empty = pd.DataFrame()
+        assert DataProcessor.filter_data(empty, start_date='2026-01-01').empty
+
+
+class TestProcessDailyData:
+    def test_ma_columns_added(self, daily_df):
+        out = DataProcessor.process_daily_data(daily_df)
+        for w in MA_WINDOWS:
+            assert f'ma{w}' in out.columns
+
+    def test_ma5_grouped_by_code(self, daily_df):
+        """均线必须按股票分组计算，不能跨股票串窗口"""
+        out = DataProcessor.process_daily_data(daily_df)
+        row = out[(out['code'] == '000001') & (out['date'] == '2026-01-10')].iloc[0]
+        # 000001 第 2-6 天 close = 11..15，ma5 = 13
+        assert row['ma5'] == pytest.approx(13.0)
+        # 窗口不足的行为 NaN
+        first = out[(out['code'] == '600000') & (out['date'] == '2026-01-05')].iloc[0]
+        assert pd.isna(first['ma5'])
+
+    def test_empty_df_passthrough(self):
+        assert DataProcessor.process_daily_data(pd.DataFrame()).empty
+
+    def test_does_not_mutate_input(self, daily_df):
+        before = daily_df.copy()
+        DataProcessor.process_daily_data(daily_df)
+        pd.testing.assert_frame_equal(daily_df, before)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,17 @@
+"""模块导入冒烟测试——捕捉 F821 类漏网错误和 import 期崩溃（issue #14）"""
+
+import importlib
+
+import pytest
+
+
+@pytest.mark.parametrize('module', [
+    'src.config',
+    'src.logger',
+    'src.processor',
+    'src.reader',
+    'src.storage',
+    'src.cli',
+])
+def test_module_imports(module):
+    importlib.import_module(module)


### PR DESCRIPTION
Closes #14

## Summary

`Python package` workflow 三个 Python 版本（3.9/3.10/3.11）持续失败，与版本无关，根因两层：

1. **flake8 F821**：`src/reader.py:435` `return df` 引用未定义变量。`get_block_stock_relation` 函数体大部分被注释（板块关系功能标注未实现），末尾 return 漏了注释。改为 `return blocks`（pytdx BlockReader 实际读取的数据，符合 docstring）
2. **pytest 退出码 5**：仓库无测试套件，lint 修复后 `Test with pytest` 步骤会因无测试收集而失败。补最小真实测试套件而非绕过：
   - `tests/test_processor.py`：filter_data 日期边界（含端点）/ code 筛选 / 空表透传；process_daily_data 均线列生成、**按 code 分组不串窗口**、不篡改输入
   - `tests/test_smoke.py`：src 全模块导入冒烟（正是能拦住本次 F821 这类注释残留错误的防线）

## 已知边界（不在本 PR 范围）

`get_block_stock_relation` 在本机 TDX 数据上运行时会在 pytdx BlockReader 层抛 struct.error（master 同样如此，崩在本次改动之前的第 308 行）——功能本身未实现完（CLI 标注【未实现】），本 PR 只修 lint 层错误，不改变其运行时行为。

## Test plan

- [x] 本地 `pytest tests/ -q` → 15 passed
- [x] 本地 `flake8 . --count --select=E9,F63,F7,F82` → 0 错误
- [x] `get_block_stock_relation` 运行时行为与 master 一致（同在 pytdx 读取层报错，无回归）
- [ ] CI 三矩阵转绿（推 PR 后观察）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJPL3yLZNViUNDnPNzVDsD
