### PR TITLE
fix: 唯一约束内建进模型，修复新用户增量同步防呆缺口

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ CLI (cli.py)  → Reader (reader.py) → Processor (processor.py) → Storage (s
 | `stock_info` | code | 股票列表 |
 | `block_stock_relation` | — | 板块关系（未完整实现） |
 
-唯一约束需通过 `scripts/add_constraints.sql` 手动添加。
+唯一约束已内建于 `src/storage.py` 的模型定义（`create_all` 自动创建）；仅老库（PR #17 之前建的表）需执行 `scripts/add_constraints.sql` / `add_constraints_mysql.sql` 迁移。
 
 ### 股票代码格式
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,17 @@ python main.py sync
 
 **新用户**：无需任何操作——表结构由程序自动创建，已内建唯一约束。
 
-**老用户**（v0.2.0 之前建的表没有约束）需执行一次迁移脚本，**否则 PostgreSQL 下增量写入会全部失败、MySQL/SQLite 下会静默累积重复数据**：
+**老用户**（v0.2.0 之前建的表没有约束）需执行一次迁移脚本，**否则 PostgreSQL 下增量写入会全部失败、MySQL/SQLite 下会静默累积重复数据**。不确定的话可先自检：
+
+```sql
+-- PostgreSQL：有输出说明约束已存在，无需迁移
+SELECT conname FROM pg_constraint WHERE conname LIKE 'uq_%';
+-- MySQL
+SELECT CONSTRAINT_NAME FROM information_schema.TABLE_CONSTRAINTS
+WHERE CONSTRAINT_SCHEMA = DATABASE() AND CONSTRAINT_NAME LIKE 'uq_%';
+```
+
+迁移脚本：
 ```bash
 # PostgreSQL
 psql -U your_user -d your_database -f scripts/add_constraints.sql

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ pip install -r requirements.txt
 
 # 复制并编辑配置文件
 cp .env.example .env
+
+# 创建数据库（表结构会在首次运行时自动创建，但数据库本身需要先建好）
+createdb tdx_data                          # PostgreSQL
+# mysql -u root -p -e 'CREATE DATABASE tdx_data'   # MySQL
+# SQLite 无需此步骤
 ```
 
 **.env 必填配置**：
@@ -43,19 +48,22 @@ python main.py stock-list --db-only
 python main.py sync
 ```
 
-## 启用增量同步（推荐）
+## 增量同步与唯一约束
 
-> 增量同步可自动跳过重复数据，大幅提升每日更新效率。
+增量同步（自动跳过重复数据）依赖 `(code, date/datetime)` 唯一约束。
 
-**老用户**（已有数据库表）需执行一次约束脚本：
+**新用户**：无需任何操作——表结构由程序自动创建，已内建唯一约束。
+
+**老用户**（v0.2.0 之前建的表没有约束）需执行一次迁移脚本，**否则 PostgreSQL 下增量写入会全部失败、MySQL/SQLite 下会静默累积重复数据**：
 ```bash
 # PostgreSQL
 psql -U your_user -d your_database -f scripts/add_constraints.sql
+
+# MySQL
+mysql -u your_user -p your_database < scripts/add_constraints_mysql.sql
 ```
 
-**新用户**同样建议执行，以启用增量同步功能。
-
-脚本作用：为 `daily_data`、`minute*_data` 表添加唯一约束，确保 `(code, date/datetime)` 不重复。
+脚本会先清理已有重复数据再加约束，执行前请备份。
 
 ## 每日更新
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ sqlalchemy>=2.0.40
 tqdm>=4.67.1
 python-dotenv>=1.1.0
 psycopg2-binary>=2.9.10
+pymysql>=1.1.1

--- a/scripts/add_constraints_mysql.sql
+++ b/scripts/add_constraints_mysql.sql
@@ -1,0 +1,60 @@
+-- 增量同步约束脚本（MySQL 版）
+-- 为各数据表添加唯一约束，确保 (code, date/datetime) 组合唯一
+-- 仅老用户需要：v0.2.0 起表由 SQLAlchemy 模型自动携带约束，新建库无需执行本脚本
+-- 执行前请先备份数据库
+--
+-- 注意：无约束期间 INSERT IGNORE 不报错，重复数据可能已大量累积，
+-- 第一步的去重删除可能影响大量行，务必先备份
+
+-- ============================================
+-- 第一步：清理重复数据（如有）
+-- ============================================
+
+DELETE a FROM daily_data a
+JOIN daily_data b ON a.code = b.code AND a.date = b.date AND a.id < b.id;
+
+DELETE a FROM minute5_data a
+JOIN minute5_data b ON a.code = b.code AND a.datetime = b.datetime AND a.id < b.id;
+
+DELETE a FROM minute15_data a
+JOIN minute15_data b ON a.code = b.code AND a.datetime = b.datetime AND a.id < b.id;
+
+DELETE a FROM minute30_data a
+JOIN minute30_data b ON a.code = b.code AND a.datetime = b.datetime AND a.id < b.id;
+
+DELETE a FROM minute60_data a
+JOIN minute60_data b ON a.code = b.code AND a.datetime = b.datetime AND a.id < b.id;
+
+DELETE a FROM block_stock_relation a
+JOIN block_stock_relation b ON a.block_code = b.block_code AND a.code = b.code AND a.id < b.id;
+
+-- ============================================
+-- 第二步：添加唯一约束（命名与 SQLAlchemy 模型一致）
+-- ============================================
+
+ALTER TABLE daily_data
+ADD CONSTRAINT uq_daily_code_date UNIQUE (code, date);
+
+ALTER TABLE minute5_data
+ADD CONSTRAINT uq_minute5_code_datetime UNIQUE (code, datetime);
+
+ALTER TABLE minute15_data
+ADD CONSTRAINT uq_minute15_code_datetime UNIQUE (code, datetime);
+
+ALTER TABLE minute30_data
+ADD CONSTRAINT uq_minute30_code_datetime UNIQUE (code, datetime);
+
+ALTER TABLE minute60_data
+ADD CONSTRAINT uq_minute60_code_datetime UNIQUE (code, datetime);
+
+ALTER TABLE block_stock_relation
+ADD CONSTRAINT uq_block_code UNIQUE (block_code, code);
+
+-- stock_info 表：code 已有唯一索引，无需额外操作
+
+-- ============================================
+-- 验证约束（可选）
+-- ============================================
+
+-- SELECT TABLE_NAME, CONSTRAINT_NAME FROM information_schema.TABLE_CONSTRAINTS
+-- WHERE CONSTRAINT_SCHEMA = DATABASE() AND CONSTRAINT_NAME LIKE 'uq_%';

--- a/src/cli.py
+++ b/src/cli.py
@@ -11,6 +11,7 @@ from typing import Optional
 from datetime import timedelta
 
 import pandas as pd
+from sqlalchemy.exc import OperationalError
 from tqdm import tqdm
 
 from .reader import TdxDataReader
@@ -301,7 +302,18 @@ def main() -> int:
         return 1
 
     # 初始化数据存储器
-    storage = DataStorage()
+    try:
+        storage = DataStorage()
+    except OperationalError as e:
+        logger.error(f"数据库连接失败: {e.orig if e.orig else e}")
+        logger.error(
+            "请依次检查：\n"
+            f"  1) 数据库服务是否已启动（{config.db_type} @ {config.db_host}:{config.db_port}）\n"
+            f"  2) 数据库 {config.db_name} 是否已创建（PostgreSQL: createdb {config.db_name}；"
+            f"MySQL: CREATE DATABASE {config.db_name}）\n"
+            "  3) .env 中 DB_USER / DB_PASSWORD 等配置是否正确"
+        )
+        return 1
 
     # 处理子命令
     if args.command == 'stock-list':

--- a/src/storage.py
+++ b/src/storage.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Optional, Tuple
 
 import pandas as pd
-from sqlalchemy import create_engine, Column, Integer, Float, String, DateTime, MetaData, Table, text
+from sqlalchemy import create_engine, Column, Integer, Float, String, DateTime, MetaData, Table, UniqueConstraint, text
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from tqdm import tqdm
@@ -24,6 +24,9 @@ Base = declarative_base()
 class BlockStockRelation(Base):
     """板块股票关系表模型"""
     __tablename__ = 'block_stock_relation'
+    # 唯一约束是 save_incremental 增量写入（ON CONFLICT / INSERT IGNORE）的前提，
+    # 缺失时 PG 会报错、MySQL/SQLite 会静默重复累积（issue #16）
+    __table_args__ = (UniqueConstraint('block_code', 'code', name='uq_block_code'),)
 
     id = Column(Integer, primary_key=True)
     block_code = Column(String(20), index=True)  # 板块代码
@@ -34,6 +37,7 @@ class BlockStockRelation(Base):
 class DailyData(Base):
     """日线数据表模型"""
     __tablename__ = 'daily_data'
+    __table_args__ = (UniqueConstraint('code', 'date', name='uq_daily_code_date'),)
 
     id = Column(Integer, primary_key=True)
     code = Column(String(10), index=True)
@@ -61,6 +65,7 @@ class DailyData(Base):
 class Minute5Data(Base):
     """5分钟线数据表模型"""
     __tablename__ = 'minute5_data'
+    __table_args__ = (UniqueConstraint('code', 'datetime', name='uq_minute5_code_datetime'),)
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     code = Column(String(10), nullable=False, index=True)
@@ -88,6 +93,7 @@ class Minute5Data(Base):
 class Minute15Data(Base):
     """15分钟线数据表模型"""
     __tablename__ = 'minute15_data'
+    __table_args__ = (UniqueConstraint('code', 'datetime', name='uq_minute15_code_datetime'),)
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     code = Column(String(10), nullable=False, index=True)
@@ -115,6 +121,7 @@ class Minute15Data(Base):
 class Minute30Data(Base):
     """30分钟线数据表模型"""
     __tablename__ = 'minute30_data'
+    __table_args__ = (UniqueConstraint('code', 'datetime', name='uq_minute30_code_datetime'),)
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     code = Column(String(10), nullable=False, index=True)
@@ -143,6 +150,7 @@ class Minute30Data(Base):
 class Minute60Data(Base):
     """60分钟线数据表模型"""
     __tablename__ = 'minute60_data'
+    __table_args__ = (UniqueConstraint('code', 'datetime', name='uq_minute60_code_datetime'),)
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     code = Column(String(10), nullable=False, index=True)
@@ -347,7 +355,17 @@ class DataStorage:
                 with self.engine.connect() as conn:
                     for i in range(0, total_rows, batch_size):
                         batch_df = df_to_save.iloc[i:i + batch_size]
-                        conn.execute(sql, batch_df.to_dict('records'))
+                        # sqlite3 适配器按精确类型匹配，不识别 pd.Timestamp（虽是
+                        # datetime 子类）；先转 dict 再逐值转换，避开 pandas 类型推断
+                        records = [
+                            {
+                                k: (None if pd.isna(v) else
+                                    v.to_pydatetime() if isinstance(v, pd.Timestamp) else v)
+                                for k, v in rec.items()
+                            }
+                            for rec in batch_df.to_dict('records')
+                        ]
+                        conn.execute(sql, records)
                         conn.commit()
 
             logger.info(f"增量保存完成: 共处理 {total_rows} 条到表 {table_name}（重复数据已跳过）")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,53 @@
+"""storage 约束与增量写入测试（issue #16：唯一约束内建进模型）"""
+
+import pandas as pd
+import pytest
+from sqlalchemy import inspect, text
+
+from src.config import config
+from src.storage import DataStorage
+
+
+@pytest.fixture
+def sqlite_storage(tmp_path, monkeypatch):
+    """SQLite 内存库，隔离于真实环境配置"""
+    monkeypatch.setattr(config, 'db_type', 'sqlite')
+    return DataStorage(db_url='sqlite://', csv_path=str(tmp_path))
+
+
+def _daily_df():
+    return pd.DataFrame([
+        {
+            'code': code, 'market': 0,
+            'datetime': day, 'date': day,
+            'open': 10.0, 'high': 10.5, 'low': 9.5, 'close': 10.2,
+            'volume': 1000.0, 'amount': 10200.0,
+        }
+        for code in ['000001', '600000']
+        for day in pd.date_range('2026-01-05', periods=3)
+    ])
+
+
+def test_create_all_builds_unique_constraints(sqlite_storage):
+    """create_all 自动携带唯一约束，新用户无需手动跑迁移脚本"""
+    insp = inspect(sqlite_storage.engine)
+    daily_uqs = [set(u['column_names']) for u in insp.get_unique_constraints('daily_data')]
+    assert {'code', 'date'} in daily_uqs
+    for tbl in ['minute5_data', 'minute15_data', 'minute30_data', 'minute60_data']:
+        uqs = [set(u['column_names']) for u in insp.get_unique_constraints(tbl)]
+        assert {'code', 'datetime'} in uqs, tbl
+
+
+def test_duplicate_incremental_insert_is_ignored(sqlite_storage):
+    """重复写入被约束去重——无约束时会静默累积（issue #16 的核心回归）"""
+    df = _daily_df()
+    sqlite_storage.save_incremental(df, 'daily_data', conflict_columns=('code', 'date'))
+    sqlite_storage.save_incremental(df, 'daily_data', conflict_columns=('code', 'date'))
+    with sqlite_storage.engine.connect() as conn:
+        n = conn.execute(text("SELECT COUNT(*) FROM daily_data")).scalar()
+    assert n == len(df)
+
+
+def test_save_incremental_rejects_unknown_table(sqlite_storage):
+    with pytest.raises(ValueError):
+        sqlite_storage.save_incremental(_daily_df(), 'evil_table', conflict_columns=('code', 'date'))


### PR DESCRIPTION
Closes #16

## Summary

**问题**：`sync` 的写入路径依赖 (code, date/datetime) 唯一约束，但 `create_all` 建的表没有约束。PostgreSQL 新用户不手动跑约束脚本时，增量写入全部报错被吞、输出"同步完成"且 exit 0，实际 0 行入库；MySQL/SQLite 用户则无报错地永久累积重复数据。

**改动**：
- 六张表模型声明 `UniqueConstraint`（命名与既有迁移脚本一致，存量库无冲突），新建库自动携带约束，手动脚本降级为老用户迁移用
- 修复 MySQL/SQLite 增量路径 `pd.Timestamp` 绑定错误（sqlite3 适配器按精确类型匹配）——方案移植自 @jaden1q84 的 #6，已 Co-authored-by 致谢
- `DataStorage` 连接失败输出中文可行动指引（服务是否启动 / 建库命令 / .env 检查项），exit 1
- 新增 `scripts/add_constraints_mysql.sql`（老 MySQL 用户迁移）
- README：安装节补建库步骤；约束章节按"新用户零操作 / 老用户必须迁移"改写
- 新增 `tests/test_storage.py`（SQLite 内存库端到端）：约束自动生成、重复写入去重、表名白名单拒绝

## Test plan

- [x] `pytest tests/ -q` → 18 passed（含 3 个新增）
- [x] flake8 严格检查 0 错误
- [x] 真实 PostgreSQL 幂等冒烟：存量库（已有同名约束）上单股票增量运行正常，create_all 不影响已存在的表
- [x] 连接失败路径：不存在的库名 → 中文指引 + exit 1
- [x] 重复写入回归：SQLite 内存库写两遍，行数 == 单遍（此前因 Timestamp 绑定错误根本写不进去）

🤖 Generated with [Claude Code](https://claude.com/claude-code)