### PR TITLE
fix: 安全硬化——白名单补全 / Actions 最小权限 / 密码处理

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ DB_HOST=localhost
 DB_PORT=5432
 DB_NAME=tdx_data
 DB_USER=postgres
-DB_PASSWORD=postgres
+DB_PASSWORD=your_password
 DB_BATCH_SIZE=1000
 
 # 输出CSV路径

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 
@@ -21,7 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ poetry.lock
 output/
 
 */__pycache__/
+
+# 内部复盘笔记（不入公开仓库）
+retrospectives/

--- a/src/cli.py
+++ b/src/cli.py
@@ -302,6 +302,9 @@ def main() -> int:
     # 初始化数据存储器
     try:
         storage = DataStorage()
+    except ValueError as e:
+        logger.error(f"数据库配置错误: {e}")
+        return 1
     except OperationalError as e:
         logger.error(f"数据库连接失败: {e.orig if e.orig else e}")
         logger.error(

--- a/src/cli.py
+++ b/src/cli.py
@@ -207,7 +207,7 @@ def parse_args() -> Namespace:
     parser.add_argument('--db-port', help='数据库端口')
     parser.add_argument('--db-name', help='数据库名称')
     parser.add_argument('--db-user', help='数据库用户名')
-    parser.add_argument('--db-password', help='数据库密码')
+    # 不提供 --db-password：argv 中的密码会暴露于进程列表和 shell 历史，密码只从 .env 读取
     parser.add_argument('--no-tqdm', action='store_true', help='禁用进度条')
     parser.add_argument('--batch-size', type=int, default=10000, help='数据库批量插入的批次大小，默认10000条')
 
@@ -276,8 +276,6 @@ def update_config(args: Namespace) -> None:
         config.db_name = args.db_name
     if args.db_user:
         config.db_user = args.db_user
-    if args.db_password:
-        config.db_password = args.db_password
     if args.batch_size:
         config.db_batch_size = args.batch_size
 

--- a/src/config.py
+++ b/src/config.py
@@ -67,12 +67,17 @@ class Config:
         else:
             raise ValueError(f"不支持的数据库类型: {self.db_type}")
 
+        try:
+            port = int(self.db_port)
+        except (TypeError, ValueError):
+            raise ValueError(f"DB_PORT 配置无效（应为数字）: {self.db_port!r}，请检查 .env")
+
         return URL.create(
             drivername,
             username=self.db_user,
             password=self.db_password or None,
             host=self.db_host,
-            port=int(self.db_port),
+            port=port,
             database=self.db_name,
         )
 

--- a/src/config.py
+++ b/src/config.py
@@ -51,15 +51,30 @@ class Config:
 
     @property
     def database_url(self):
-        """获取数据库连接URL"""
+        """获取数据库连接URL
+
+        用 URL.create 而非 f-string 拼接：密码含 @ : / 等字符时不会解析错乱，
+        且 URL 对象在日志/异常中自动掩码密码。
+        """
+        from sqlalchemy import URL
+
         if self.db_type == 'postgresql':
-            return f"postgresql://{self.db_user}:{self.db_password}@{self.db_host}:{self.db_port}/{self.db_name}"
+            drivername = 'postgresql'
         elif self.db_type == 'mysql':
-            return f"mysql+pymysql://{self.db_user}:{self.db_password}@{self.db_host}:{self.db_port}/{self.db_name}"
+            drivername = 'mysql+pymysql'
         elif self.db_type == 'sqlite':
-            return f"sqlite:///{self.db_name}.db"
+            return URL.create('sqlite', database=f"{self.db_name}.db")
         else:
             raise ValueError(f"不支持的数据库类型: {self.db_type}")
+
+        return URL.create(
+            drivername,
+            username=self.db_user,
+            password=self.db_password or None,
+            host=self.db_host,
+            port=int(self.db_port),
+            database=self.db_name,
+        )
 
 # 创建全局配置实例
 config = Config()

--- a/src/storage.py
+++ b/src/storage.py
@@ -252,6 +252,10 @@ class DataStorage:
         Returns:
             Optional[datetime]: 最新的日期/时间，如果表为空则返回 None
         """
+        if table_name not in _VALID_TABLES:
+            raise ValueError(f"不允许查询的表名: {table_name}")
+        if date_column not in ('datetime', 'date'):
+            raise ValueError(f"非法日期列名: {date_column}")
         try:
             with self.engine.connect() as conn:
                 result = conn.execute(
@@ -281,6 +285,8 @@ class DataStorage:
         Returns:
             Optional[datetime]: 最新的 datetime，如果没有数据则返回 None
         """
+        if table_name not in _VALID_TABLES:
+            raise ValueError(f"不允许查询的表名: {table_name}")
         if date_column not in ('datetime', 'date'):
             raise ValueError(f"非法日期列名: {date_column}")
         try:
@@ -421,6 +427,9 @@ class DataStorage:
         Returns:
             bool: 是否保存成功
         """
+        if table_name not in _VALID_TABLES:
+            raise ValueError(f"不允许写入的表名: {table_name}")
+
         if df.empty:
             logger.warning(f"没有数据可保存到表 {table_name}")
             return False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -50,3 +50,11 @@ def test_unknown_db_type_raises(monkeypatch):
     monkeypatch.setattr(config, 'db_type', 'oracle')
     with pytest.raises(ValueError):
         _ = config.database_url
+
+
+def test_non_numeric_port_raises_clear_error(pg_config, monkeypatch):
+    """DB_PORT 手滑配错时给明确配置错误，而非裸 traceback"""
+    monkeypatch.setattr(config, 'db_password', 'x')
+    monkeypatch.setattr(config, 'db_port', '5432"')
+    with pytest.raises(ValueError, match='DB_PORT'):
+        _ = config.database_url

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,52 @@
+"""config 数据库 URL 构造测试（issue #18：URL.create 替代 f-string 拼接）"""
+
+import pytest
+from sqlalchemy import URL
+
+from src.config import config
+
+
+@pytest.fixture
+def pg_config(monkeypatch):
+    monkeypatch.setattr(config, 'db_type', 'postgresql')
+    monkeypatch.setattr(config, 'db_host', 'db.example.com')
+    monkeypatch.setattr(config, 'db_port', '5432')
+    monkeypatch.setattr(config, 'db_name', 'tdx_data')
+    monkeypatch.setattr(config, 'db_user', 'tdx')
+    return config
+
+
+def test_special_chars_in_password_survive(pg_config, monkeypatch):
+    """密码含 @ : / 时 f-string 拼接会解析错乱，URL.create 必须原样保留"""
+    monkeypatch.setattr(config, 'db_password', 'p@ss:w/rd')
+    url = config.database_url
+    assert isinstance(url, URL)
+    assert url.password == 'p@ss:w/rd'
+    assert url.host == 'db.example.com'
+    assert url.database == 'tdx_data'
+
+
+def test_password_masked_in_str(pg_config, monkeypatch):
+    """URL 对象默认渲染掩码密码，避免异常链/日志泄漏"""
+    monkeypatch.setattr(config, 'db_password', 'secret123')
+    assert 'secret123' not in str(config.database_url)
+
+
+def test_mysql_drivername(pg_config, monkeypatch):
+    monkeypatch.setattr(config, 'db_type', 'mysql')
+    monkeypatch.setattr(config, 'db_password', 'x')
+    assert config.database_url.drivername == 'mysql+pymysql'
+
+
+def test_sqlite_url(monkeypatch):
+    monkeypatch.setattr(config, 'db_type', 'sqlite')
+    monkeypatch.setattr(config, 'db_name', 'tdx_data')
+    url = config.database_url
+    assert url.drivername == 'sqlite'
+    assert url.database == 'tdx_data.db'
+
+
+def test_unknown_db_type_raises(monkeypatch):
+    monkeypatch.setattr(config, 'db_type', 'oracle')
+    with pytest.raises(ValueError):
+        _ = config.database_url


### PR DESCRIPTION
Closes #18

## Summary

安全审计后的防御性硬化，无一项是当前可利用的漏洞，均为公开库的防御纵深：

- **storage 白名单补全**：`get_latest_datetime`（表名 + 日期列名双重校验）、`get_latest_datetime_by_code` / `save_to_database`（表名）——与 `save_incremental` 既有防护对齐。DataStorage 是被下游直接 import 的公开 API
- **GitHub Actions**：顶层 `permissions: contents: read`（GITHUB_TOKEN 最小化）；`setup-python` v3 → v5（v3 基于已弃用的 node16）
- **移除 `--db-password` 参数**：argv 中的密码暴露于进程列表与 shell 历史，密码仅从 .env 读取（breaking：极少数依赖该参数的用户需迁移到 .env）
- **`database_url` 改 `sqlalchemy.URL.create`**：密码含 `@` `:` `/` 不再解析错乱；URL 对象在日志/异常中自动掩码密码
- **.env.example**：`DB_PASSWORD=postgres` → `your_password`（不再引导全网最常被扫的弱凭据组合）
- `.gitignore` 排除内部复盘目录

## Test plan

- [x] `pytest tests/ -q` → 23 passed（新增 5 个 config URL 测试：特殊字符密码保真、str 渲染掩码、mysql drivername、sqlite、非法类型）
- [x] flake8 严格检查 0 错误
- [x] 真实 PostgreSQL 冒烟：URL 对象直接传 create_engine，单股票增量运行正常
- [x] CI 三矩阵（观察本 PR checks）

🤖 Generated with [Claude Code](https://claude.com/claude-code)