### PR TITLE
feat: CLI 可观测性与防呆——market 推断 / 日志降噪 / 汇总退出码

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@ DB_PORT=5432
 DB_NAME=tdx_data
 DB_USER=postgres
 DB_PASSWORD=your_password
-DB_BATCH_SIZE=1000
+DB_BATCH_SIZE=10000
 
 # 输出CSV路径
 CSV_OUTPUT_PATH=./output

--- a/src/cli.py
+++ b/src/cli.py
@@ -21,6 +21,16 @@ from .config import config
 from .logger import logger
 
 
+def infer_market(code: str) -> int:
+    """从股票代码推断市场：sh/sz 前缀直接判定；6 位纯数字按首位（6/68 沪，其余深）"""
+    c = code.lower()
+    if c.startswith('sh'):
+        return 1
+    if c.startswith('sz'):
+        return 0
+    return 1 if c.startswith('6') else 0
+
+
 def sync_single_stock_min_data(
     reader: TdxDataReader,
     processor: DataProcessor,
@@ -91,7 +101,7 @@ def sync_single_stock_min_data(
             storage.save_minute_data(processed, freq=freq, to_csv=False, to_db=True)
 
     if has_data:
-        logger.info(f"{code} 分钟数据已处理并存入数据库")
+        logger.debug(f"{code} 分钟数据已处理并存入数据库")
     else:
         logger.debug(f"{code} 无新数据需要同步")
 
@@ -115,6 +125,7 @@ def sync_all_daily_data(
 
         iterator = tqdm(stocks.iterrows(), total=len(stocks)) if config.use_tqdm else stocks.iterrows()
         total_inserted = 0
+        failed = 0
 
         for _, stock in iterator:
             code = stock['code']
@@ -149,13 +160,20 @@ def sync_all_daily_data(
             except FileNotFoundError:
                 continue
             except Exception as e:
+                failed += 1
                 logger.error(f"同步 {code} 日线数据时出错: {e}")
                 continue
 
         if total_inserted > 0:
-            logger.info(f"日线数据同步完成，共插入 {total_inserted} 条")
+            logger.info(f"日线数据同步完成，共处理 {total_inserted} 条（重复已跳过）"
+                        + (f"，{failed} 只股票失败" if failed else ""))
         else:
-            logger.info("日线数据已是最新")
+            logger.info("日线数据已是最新" + (f"（{failed} 只股票失败）" if failed else ""))
+
+        # 失败率超 1% 视为整体失败——cron 用户靠退出码监控
+        if len(stocks) and failed / len(stocks) > 0.01:
+            logger.error(f"日线同步失败率过高: {failed}/{len(stocks)}")
+            return False
         return True
     except Exception as e:
         logger.error(f"同步日线数据时出错: {e}")
@@ -174,18 +192,33 @@ def sync_all_min_data(
         logger.info(f"处理所有股票的分钟数据，共 {len(stocks)} 只股票")
 
         iterator = tqdm(stocks.iterrows(), total=len(stocks)) if config.use_tqdm else stocks.iterrows()
+        synced = 0
+        nodata = 0
+        failed = 0
 
         for _, stock in iterator:
             code = stock['code']
             market = 1 if code.startswith('sh') else 0
             try:
-                sync_single_stock_min_data(reader, processor, storage, market, code, start_date)
+                if sync_single_stock_min_data(reader, processor, storage, market, code, start_date):
+                    synced += 1
+                else:
+                    nodata += 1
             except FileNotFoundError:
+                nodata += 1
                 continue
             except Exception as e:
+                failed += 1
                 logger.error(f"处理 {code} 分钟数据时出错: {e}")
                 continue
 
+        logger.info(f"分钟数据同步完成：{synced} 只已处理，{nodata} 只无数据"
+                    + (f"，{failed} 只失败" if failed else ""))
+
+        # 失败率超 1% 视为整体失败——cron 用户靠退出码监控
+        if len(stocks) and failed / len(stocks) > 0.01:
+            logger.error(f"分钟同步失败率过高: {failed}/{len(stocks)}")
+            return False
         return True
     except Exception as e:
         logger.error(f"处理分钟数据时出错: {e}")
@@ -197,7 +230,18 @@ def parse_args() -> Namespace:
     Returns:
         Namespace: 解析后的命令行参数
     """
-    parser = argparse.ArgumentParser(description='通达信数据处理工具')
+    parser = argparse.ArgumentParser(
+        description='通达信数据处理工具',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            '典型用法:\n'
+            '  python main.py sync                                        # 日常一键增量同步（日线+分钟线）\n'
+            '  python main.py stock-list --db-only                        # 首次使用先同步股票列表\n'
+            '  python main.py daily --db-only --code 600000 --incremental # 单股票补数（market 自动推断）\n'
+            '\n'
+            '注意: --no-tqdm 等全局参数需放在子命令之前，如 python main.py --no-tqdm sync'
+        ),
+    )
 
     # 通用参数
     parser.add_argument('--tdx-path', help='通达信安装目录路径')
@@ -209,7 +253,8 @@ def parse_args() -> Namespace:
     parser.add_argument('--db-user', help='数据库用户名')
     # 不提供 --db-password：argv 中的密码会暴露于进程列表和 shell 历史，密码只从 .env 读取
     parser.add_argument('--no-tqdm', action='store_true', help='禁用进度条')
-    parser.add_argument('--batch-size', type=int, default=10000, help='数据库批量插入的批次大小，默认10000条')
+    # 默认 None：不覆盖 .env 的 DB_BATCH_SIZE（此前默认 10000 恒为真值，.env 配置永远不生效）
+    parser.add_argument('--batch-size', type=int, default=None, help='数据库批量插入的批次大小（默认取 .env 的 DB_BATCH_SIZE，缺省 10000）')
 
     # 子命令
     subparsers = parser.add_subparsers(dest='command', help='子命令')
@@ -222,9 +267,9 @@ def parse_args() -> Namespace:
     # 获取日线数据
     daily_parser = subparsers.add_parser('daily', help='获取日线数据')
     daily_parser.add_argument('--code', help='股票代码，不指定则获取所有股票')
-    daily_parser.add_argument('--market', type=int, choices=[0, 1], help='市场代码，0表示深圳，1表示上海')
-    daily_parser.add_argument('--start_date', help='开始日期，格式为YYYY-MM-DD')
-    daily_parser.add_argument('--end_date', help='结束日期，格式为YYYY-MM-DD')
+    daily_parser.add_argument('--market', type=int, choices=[0, 1], help='市场代码，0深圳 1上海（不指定则从 code 自动推断）')
+    daily_parser.add_argument('--start-date', '--start_date', dest='start_date', help='开始日期，格式为YYYY-MM-DD')
+    daily_parser.add_argument('--end-date', '--end_date', dest='end_date', help='结束日期，格式为YYYY-MM-DD')
     daily_parser.add_argument('--csv-only', action='store_true', help='仅保存到CSV')
     daily_parser.add_argument('--db-only', action='store_true', help='仅保存到数据库')
     daily_parser.add_argument('--auto-start', action='store_true', help='自动检测起始日期（逐股票精确增量，各股票从自己的最新日期+1天开始）')
@@ -233,18 +278,14 @@ def parse_args() -> Namespace:
     # 获取并计算分钟线数据
     min_parser = subparsers.add_parser('minutes', help='获取分钟线数据')
     min_parser.add_argument('--code', help='股票代码，不指定则获取所有股票')
-    min_parser.add_argument('--market', type=int, choices=[0, 1], help='市场代码，0表示深圳，1表示上海')
-    min_parser.add_argument('--start_date', help='开始日期，格式为YYYY-MM-DD')
-    min_parser.add_argument('--end_date', help='结束日期，格式为YYYY-MM-DD')
+    min_parser.add_argument('--market', type=int, choices=[0, 1], help='市场代码，0深圳 1上海（不指定则从 code 自动推断）')
+    min_parser.add_argument('--start-date', '--start_date', dest='start_date', help='开始日期，格式为YYYY-MM-DD')
+    min_parser.add_argument('--end-date', '--end_date', dest='end_date', help='结束日期，格式为YYYY-MM-DD')
     min_parser.add_argument('--csv-only', action='store_true', help='仅保存到CSV')
     min_parser.add_argument('--db-only', action='store_true', help='仅保存到数据库')
     min_parser.add_argument('--auto-start', action='store_true', help='自动检测起始日期（从数据库最新日期+1天开始）')
     min_parser.add_argument('--incremental', action='store_true', help='增量同步模式，跳过重复数据')
 
-    # 获取板块与股票对应关系
-    block_relation_parser = subparsers.add_parser('block-relation', help='获取板块与股票对应关系【未实现】')
-    block_relation_parser.add_argument('--csv-only', action='store_true', help='仅保存到CSV')
-    block_relation_parser.add_argument('--db-only', action='store_true', help='仅保存到数据库')
 
     # 一键同步（日线 + 分钟线增量同步到数据库）
     subparsers.add_parser('sync', help='一键增量同步所有数据到数据库（日线 + 5/15/30/60分钟线）')
@@ -276,7 +317,7 @@ def update_config(args: Namespace) -> None:
         config.db_name = args.db_name
     if args.db_user:
         config.db_user = args.db_user
-    if args.batch_size:
+    if args.batch_size is not None:
         config.db_batch_size = args.batch_size
 
     # 更新进度条配置
@@ -363,9 +404,10 @@ def main() -> int:
                     logger.info(f"数据库中没有 {args.code} 的数据，将获取全部历史")
 
             # 获取日线数据
-            if args.code and args.market is not None:
-                # 获取单只股票的日线数据
-                data = reader.read_daily_data(args.market, args.code)
+            if args.code:
+                # 获取单只股票的日线数据（market 未指定时从 code 推断）
+                market = args.market if args.market is not None else infer_market(args.code)
+                data = reader.read_daily_data(market, args.code)
             else:
                 # 获取所有股票的日线数据
                 data = reader.read_all_daily_data()
@@ -431,18 +473,21 @@ def main() -> int:
             incremental = hasattr(args, 'incremental') and args.incremental
 
             # 获取分钟线数据
-            if args.code and args.market is not None:
+            if args.code:
                 # 单只股票：统一走 sync_single_stock_min_data，覆盖 5/15/30/60 全部周期
+                # market 未指定时从 code 推断（此前漏 --market 会静默进入全市场同步）
+                market = args.market if args.market is not None else infer_market(args.code)
                 processor = DataProcessor()
                 success = sync_single_stock_min_data(
                     reader, processor, storage,
-                    args.market, args.code,
+                    market, args.code,
                     start_date=start_date,
                     incremental=incremental,
                 )
                 if not success:
                     logger.warning(f"股票 {args.code} 无数据可同步")
                     return 0
+                logger.info(f"{args.code} 分钟数据同步完成")
             else:
                 # 获取所有股票的分钟线数据
                 logger.info("开始处理所有股票的分钟线数据...")
@@ -458,25 +503,10 @@ def main() -> int:
             logger.error(f"获取分钟线数据时出错: {e}")
             return 1
 
-    elif args.command == 'block-relation':
-        # 获取板块与股票对应关系
-        try:
-            block_relations = reader.get_block_stock_relation()
-            logger.info(f"获取到 {len(block_relations)} 条板块与股票对应关系记录")
-
-            # 确定保存方式
-            to_csv = not args.db_only
-            to_db = not args.csv_only
-
-            # 保存数据
-            storage.save_block_relation(block_relations, to_csv=to_csv, to_db=to_db, batch_size=config.db_batch_size)
-
-        except Exception as e:
-            logger.error(f"获取板块与股票对应关系时出错: {e}")
-            return 1
-
     elif args.command == 'sync':
         # 一键增量同步所有数据
+        import time
+        t0 = time.monotonic()
         logger.info("开始一键增量同步...")
         processor = DataProcessor()
         has_error = False
@@ -504,11 +534,12 @@ def main() -> int:
             logger.error(f"同步分钟线数据时出错: {e}")
             has_error = True
 
+        elapsed = time.monotonic() - t0
         if has_error:
-            logger.warning("同步完成，但有部分错误")
+            logger.warning(f"同步完成但有错误（耗时 {elapsed/60:.1f} 分钟），请回看上方 ERROR 日志")
             return 1
         else:
-            logger.info("一键增量同步完成！")
+            logger.info(f"一键增量同步完成！耗时 {elapsed/60:.1f} 分钟")
 
     else:
         logger.error("请指定子命令，使用 -h 查看帮助信息")

--- a/src/logger.py
+++ b/src/logger.py
@@ -4,19 +4,31 @@
 """
 
 import logging
+import os
 import sys
 from typing import Optional
+
+from dotenv import load_dotenv
+
+# 确保 .env 已加载（无论 logger 与 config 的导入先后），load_dotenv 幂等
+load_dotenv()
+
+
+def _level_from_env() -> int:
+    """从 LOG_LEVEL 环境变量（.env）读取日志级别，非法值回退 INFO"""
+    level = getattr(logging, os.getenv('LOG_LEVEL', 'INFO').upper(), None)
+    return level if isinstance(level, int) else logging.INFO
 
 
 def setup_logger(
     name: str = "tdx2db",
-    level: int = logging.INFO
+    level: Optional[int] = None
 ) -> logging.Logger:
     """配置并返回logger实例
 
     Args:
         name: logger名称
-        level: 日志级别
+        level: 日志级别，None 时取 .env 的 LOG_LEVEL（缺省 INFO）
 
     Returns:
         配置好的Logger实例
@@ -32,7 +44,7 @@ def setup_logger(
         handler.setFormatter(formatter)
         logger.addHandler(handler)
 
-    logger.setLevel(level)
+    logger.setLevel(level if level is not None else _level_from_env())
     return logger
 
 

--- a/src/reader.py
+++ b/src/reader.py
@@ -13,7 +13,6 @@ from typing import Optional, List
 
 import pandas as pd
 from pytdx.reader import TdxDailyBarReader, TdxMinBarReader, TdxLCMinBarReader
-from pytdx.reader import BlockReader
 from tqdm import tqdm
 
 from .config import config
@@ -41,7 +40,6 @@ class TdxDataReader:
         self.daily_reader = TdxDailyBarReader()
         self.min_reader = TdxMinBarReader()
         self.lc_min_reader = TdxLCMinBarReader()
-        self.block_reader = BlockReader()
 
     def get_stock_list(self) -> pd.DataFrame:
         """获取股票列表
@@ -160,13 +158,11 @@ class TdxDataReader:
         if not file_path.exists():
             raise FileNotFoundError(f"5分钟线数据文件不存在: {file_path}")
 
-        # 读取5分钟数据
-        logger.info(f"正在读取 {code} 的5分钟线数据...")
-        with tqdm(total=1, desc="读取进度") as pbar:
-            data = self.lc_min_reader.get_df(str(file_path))
-            data['code'] = code
-            data['market'] = market
-            pbar.update(1)
+        # 读取5分钟数据（per-stock 日志降为 debug：全量同步时 5000+ 只的 INFO 会淹没进度条）
+        logger.debug(f"正在读取 {code} 的5分钟线数据...")
+        data = self.lc_min_reader.get_df(str(file_path))
+        data['code'] = code
+        data['market'] = market
 
         # 确保datetime列存在并且是日期时间类型
         if 'datetime' not in data.columns:
@@ -215,13 +211,11 @@ class TdxDataReader:
         if not file_path.exists():
             raise FileNotFoundError(f"5分钟线数据文件不存在: {file_path}")
 
-        # 读取5分钟数据
-        logger.info(f"正在读取 {code} 的5分钟线数据...")
-        with tqdm(total=1, desc="读取进度") as pbar:
-            data = self.lc_min_reader.get_df(str(file_path))
-            data['code'] = code
-            data['market'] = market
-            pbar.update(1)
+        # 读取5分钟数据（per-stock 日志降为 debug，理由同上）
+        logger.debug(f"正在读取 {code} 的5分钟线数据...")
+        data = self.lc_min_reader.get_df(str(file_path))
+        data['code'] = code
+        data['market'] = market
 
         # 确保datetime列存在并且是日期时间类型
         if 'datetime' not in data.columns:
@@ -292,144 +286,3 @@ class TdxDataReader:
 
         return result_df
 
-    # 板块关系暂时未实现，由于板块文件未找到
-    def get_block_stock_relation(self) -> pd.DataFrame:
-        """获取通达信板块与股票的对应关系
-
-        Returns:
-            DataFrame: 包含板块代码、板块名称和对应股票代码的DataFrame
-        """
-        # 板块文件目录
-        block_path = self.tdx_path / 'T0002' / 'hq_cache'
-
-        if not block_path.exists():
-            raise FileNotFoundError(f"板块文件目录不存在: {block_path}")
-
-        blocks = self.block_reader.get_df(self.tdx_path / 'BlockMap' / 'TdxZLSelStock.dat')
-        logger.debug(f"读取到板块数据: {len(blocks)} 条记录")
-
-        # # 板块文件列表
-        # block_files = list(block_path.glob('block*.dat'))
-        # block_files.extend(list(block_path.glob('block*.blk')))
-
-        # if not block_files:
-        #     raise FileNotFoundError(f"未找到板块文件: {block_path}")
-
-        # # 存储板块与股票的对应关系
-        # block_stock_relations = []
-
-        # # 遍历板块文件
-        # for block_file in block_files:
-        #     block_type = block_file.stem
-
-        #     try:
-        #         # 使用BlockReader读取板块文件
-        #         block_data = self.block_reader.get_df(str(block_file))
-
-        #         if block_data.empty:
-        #             continue
-
-        #         # 处理板块数据
-        #         for _, row in block_data.iterrows():
-        #             block_stock_relations.append({
-        #                 'block_code': row.get('block_code', block_type),
-        #                 'block_name': row.get('block_name', block_type),
-        #                 'code': row.get('code', ''),
-        #                 'name': row.get('name', '')
-        #             })
-        #     except Exception as e:
-        #         print(f"读取板块文件{block_file}时出错: {e}")
-
-        #         # 尝试直接读取文件内容
-        #         try:
-        #             with open(block_file, 'rb') as f:
-        #                 content = f.read()
-
-        #             # 解析板块文件内容
-        #             block_name = block_file.stem
-
-        #             # 尝试从文件名或内容中提取板块名称
-        #             if block_file.suffix.lower() == '.dat':
-        #                 # .dat文件通常是二进制格式
-        #                 try:
-        #                     # 尝试从文件头部提取板块名称
-        #                     if len(content) > 50:
-        #                         # 通达信板块文件格式可能不同，这里尝试几种常见格式
-        #                         try:
-        #                             name_bytes = content[0:50].split(b'\x00')[0]
-        #                             block_name = name_bytes.decode('gbk', errors='ignore').strip()
-        #                         except:
-        #                             pass
-        #                 except:
-        #                     pass
-
-        #             # 提取股票代码
-        #             codes = []
-
-        #             # 解析文件内容提取股票代码
-        #             if block_file.suffix.lower() == '.blk':
-        #                 # .blk文件通常是文本格式
-        #                 try:
-        #                     text_content = content.decode('gbk', errors='ignore')
-        #                     for line in text_content.split('\n'):
-        #                         line = line.strip()
-        #                         if line and not line.startswith('#'):
-        #                             # 通常格式为 1 000001 或 0 000001
-        #                             parts = line.split()
-        #                             if len(parts) >= 2:
-        #                                 market = int(parts[0])
-        #                                 code = parts[1]
-        #                                 market_prefix = 'sh' if market == 1 else 'sz'
-        #                                 codes.append(f"{market_prefix}{code}")
-        #                             else:
-        #                                 # 可能只有代码，没有市场标识
-        #                                 code = line
-        #                                 # 根据代码前缀判断市场
-        #                                 if code.startswith(('6', '5', '9')):
-        #                                     codes.append(f"sh{code}")
-        #                                 else:
-        #                                     codes.append(f"sz{code}")
-        #                 except:
-        #                     pass
-        #             elif block_file.suffix.lower() == '.dat':
-        #                 # .dat文件通常是二进制格式
-        #                 try:
-        #                     # 跳过文件头部，直接读取股票代码部分
-        #                     offset = 384  # 通常板块文件头部大小
-        #                     while offset < len(content):
-        #                         if offset + 7 <= len(content):
-        #                             market = content[offset]
-        #                             code = content[offset+1:offset+7].decode('ascii', errors='ignore')
-        #                             if code.isdigit():
-        #                                 market_prefix = 'sh' if market == 1 else 'sz'
-        #                                 codes.append(f"{market_prefix}{code}")
-        #                         offset += 7
-        #                 except:
-        #                     pass
-
-        #             # 添加到结果列表
-        #             for code in codes:
-        #                 block_stock_relations.append({
-        #                     'block_code': block_type,
-        #                     'block_name': block_name,
-        #                     'code': code,
-        #                     'name': ''
-        #                 })
-        #         except Exception as e:
-        #             print(f"直接解析板块文件{block_file}时出错: {e}")
-
-        # # 转换为DataFrame
-        # if not block_stock_relations:
-        #     return pd.DataFrame()
-
-        # df = pd.DataFrame(block_stock_relations)
-
-        # # 尝试补充股票名称
-        # try:
-        #     stocks = self.get_stock_list()
-        #     stock_dict = dict(zip(stocks['code'], stocks['name']))
-        #     df['name'] = df['code'].map(stock_dict)
-        # except Exception as e:
-        #     print(f"补充股票名称时出错: {e}")
-
-        return blocks

--- a/src/storage.py
+++ b/src/storage.py
@@ -300,7 +300,8 @@ class DataStorage:
                     return row[0]
                 return None
         except Exception as e:
-            logger.debug(f"获取表 {table_name} 股票 {code} 最新日期时出错: {e}")
+            # warning 而非 debug：此查询挂掉会静默退化为全量重扫，用户必须可见
+            logger.warning(f"获取表 {table_name} 股票 {code} 最新日期时出错（将全量重扫该股票）: {e}")
             return None
 
     def save_incremental(
@@ -374,7 +375,8 @@ class DataStorage:
                         conn.execute(sql, records)
                         conn.commit()
 
-            logger.info(f"增量保存完成: 共处理 {total_rows} 条到表 {table_name}（重复数据已跳过）")
+            # per-call 日志降为 debug：全量同步时每股 ×4 表的 INFO 会淹没进度条
+            logger.debug(f"增量保存完成: 共处理 {total_rows} 条到表 {table_name}（重复数据已跳过）")
             return total_rows
 
         except Exception as e:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,35 @@
+"""cli 纯函数测试（issue #24）"""
+
+import pytest
+
+from src.cli import infer_market, parse_args
+
+
+class TestInferMarket:
+    @pytest.mark.parametrize('code,expected', [
+        ('sh600000', 1),
+        ('sz000001', 0),
+        ('SH688001', 1),
+        ('600000', 1),
+        ('688001', 1),
+        ('000001', 0),
+        ('002594', 0),
+        ('300750', 0),
+        ('301269', 0),
+    ])
+    def test_inference(self, code, expected):
+        assert infer_market(code) == expected
+
+
+class TestArgAliases:
+    def test_hyphen_and_underscore_both_accepted(self, monkeypatch):
+        """--start-date 与旧拼写 --start_date 都能解析到同一 dest"""
+        monkeypatch.setattr('sys.argv', ['main.py', 'daily', '--start-date', '2026-01-01'])
+        assert parse_args().start_date == '2026-01-01'
+        monkeypatch.setattr('sys.argv', ['main.py', 'daily', '--start_date', '2026-01-02'])
+        assert parse_args().start_date == '2026-01-02'
+
+    def test_batch_size_default_none(self, monkeypatch):
+        """--batch-size 默认 None，不覆盖 .env 的 DB_BATCH_SIZE"""
+        monkeypatch.setattr('sys.argv', ['main.py', 'sync'])
+        assert parse_args().batch_size is None


### PR DESCRIPTION
Closes #24

## Summary

- **`--market` 可省略**：从 code 自动推断（sh/sz 前缀，或 6 位数字按 6/68 首位判沪）。修复了 `minutes --code X` 漏 `--market` 时**静默进入 5000+ 只全市场同步**的防呆缺口
- **参数命名统一**：`--start-date` / `--end-date` 连字符（与 `--db-only` 等一致），旧下划线拼写保留为别名不破坏兼容
- **日志降噪**：per-stock INFO（reader"正在读取"×5000、storage 增量保存×4 表、cli 完成行）全部降 debug；删除 reader 里每股闪一次的 `tqdm(total=1)` 假进度条——全量同步从 ~3 万行日志变成一条总进度条；单股票显式操作保留完成反馈
- **汇总与退出码**：日线/分钟线结束各打一行汇总（处理/无数据/失败只数）；**失败率 >1% 返回非 0**——此前全部股票失败也 exit 0，cron 用户无法监控；sync 结束打总耗时
- **`get_latest_datetime_by_code` 异常 debug → warning**：此查询挂掉会静默退化为全量重扫，必须用户可见
- **死配置修复**：`--batch-size` 默认 None，.env 的 `DB_BATCH_SIZE` 首次真正生效；`LOG_LEVEL` 接入 logger（此前写了也没用）
- **移除 block-relation 半成品**：子命令从 help 消失，reader 中运行时必崩的 `get_block_stock_relation`（含 120 行注释死代码）删除；表模型保留，功能需求跟踪在 issue 中

## Test plan

- [x] pytest 35 passed（新增 test_cli.py：market 推断 9 组参数化 / 双拼写别名 / batch-size 默认值）
- [x] flake8 严格 0 错误
- [x] 真实环境验证：`daily --code 600000`（无 --market）正确读取沪市数据；`minutes --code 000001 --incremental` 正确走深市并输出完成反馈；`LOG_LEVEL=DEBUG` 输出 debug 日志；help epilog 显示典型用法
- [ ] CI 三矩阵

## Breaking

无。旧参数拼写保留别名；`block-relation` 子命令移除（原本就运行时必崩且标注未实现）

🤖 Generated with [Claude Code](https://claude.com/claude-code)